### PR TITLE
Added Sass. CLI command to run webpack watch.

### DIFF
--- a/app/app.jsx
+++ b/app/app.jsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import 'sass/app.scss';
+
+var app = (
+  <div>
+    <h1>Hello from React</h1>
+    <p className="sass">Sass should have colored this orange</p>
+  </div>
+)
+
 ReactDOM.render(
-  <h1>Boilerplate</h1>,
+  app,
   document.getElementById('app')
 );

--- a/app/sass/app.scss
+++ b/app/sass/app.scss
@@ -1,0 +1,1 @@
+@import 'global';

--- a/app/sass/global.scss
+++ b/app/sass/global.scss
@@ -1,0 +1,7 @@
+body {
+  background-color: gray;
+
+  .sass {
+    color: orange;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "dev": "webpack -w"
   },
   "dependencies": {
     "body-parser": "1.13.2",
@@ -21,6 +22,9 @@
     "babel-loader": "^6.2.10",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
+    "bootstrap-sass": "^3.3.7",
+    "node-sass": "^4.4.0",
+    "sass-loader": "^4.1.1",
     "webpack": "^1.14.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+const app = __dirname + '/app';
+
 module.exports = {
   entry: './app/app.jsx',
   output: {
@@ -5,7 +7,7 @@ module.exports = {
     filename: './public/bundle.js'
   },
   resolve: {
-    root: __dirname + '/app',
+    root: app,
     extensions: ['', '.js', '.jsx']
   },
   module: {
@@ -17,6 +19,10 @@ module.exports = {
         },
         test: /\.jsx?$/,
         exclude: /(node_modules)/
+      },
+      {
+        test: /\.scss$/,
+        loaders: ['style-loader', 'css-loader', 'sass-loader']
       }
     ]
   }


### PR DESCRIPTION
Added Sass support for webpack. Any added `.scss` files just need to be imported into `app/sass/app.scss` and will be added to the bundle automatically.

Added an npm CLI command to run webpack in watch mode. `npm run dev` will bundle the assets and re-compile any that change. `npm start` should be running in another terminal to serve the bundle.