### PR TITLE
Updated mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debug": "2.2.0",
     "dotenv": "^4.0.0",
     "express": "4.13.1",
-    "mongoose": "4.5.8",
+    "mongoose": "4.8.1",
     "morgan": "1.6.1",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",


### PR DESCRIPTION
#### Description
`npm install` was giving a warning about a deprecated version of MongoDB. I updated mongoose so it shouldn't be a problem anymore.

#### Fixes
Fixes #14 

#### Changes
- Updated mongoose to latest version
